### PR TITLE
Fixing reserved keyword "gen" error

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -67,12 +67,12 @@ fn real(c: &mut Criterion) {
     b.bench_function("annotate to 1000 annotations", |b| {
         let guard = PProfGuard::new("target/annotate_flamegraph.svg");
         b.iter(|| {
-            let mut gen = rand::rngs::StdRng::seed_from_u64(0);
+            let mut r#gen = rand::rngs::StdRng::seed_from_u64(0);
             let mut map = TreeRangeMap::new();
             map.insert_directly(0, 10000);
             for i in 0..1000 {
-                let start = gen.gen_range(0..10000);
-                let end = gen.gen_range(start..10000);
+                let start = r#gen.gen_range(0..10000);
+                let end = r#gen.gen_range(start..10000);
                 map.annotate(start, end - start, a(i));
             }
         });
@@ -82,17 +82,17 @@ fn real(c: &mut Criterion) {
     b.bench_function("random inserts 10K", |b| {
         let guard = PProfGuard::new("target/insert_flamegraph.svg");
         b.iter(|| {
-            let mut gen = rand::rngs::StdRng::seed_from_u64(0);
+            let mut r#gen = rand::rngs::StdRng::seed_from_u64(0);
             let mut map = TreeRangeMap::new();
             map.insert_directly(0, 10000);
             for i in 0..1000 {
-                let start = gen.gen_range(0..10000);
-                let end = gen.gen_range(start..10000);
+                let start = r#gen.gen_range(0..10000);
+                let end = r#gen.gen_range(start..10000);
                 map.annotate(start, end - start, a(i));
             }
             for _ in 0..10_000 {
-                let start = gen.gen_range(0..10000);
-                let end = gen.gen_range(start..10000);
+                let start = r#gen.gen_range(0..10000);
+                let end = r#gen.gen_range(start..10000);
                 map.insert_directly(start, end - start);
             }
         });

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -76,9 +76,9 @@ pub fn main() {
     } else {
         println!("Running on random generated actions 10k");
         let mut rng = rand::rngs::StdRng::seed_from_u64(123);
-        let data: HeapVec<u8> = (0..1_000_000).map(|_| rng.gen()).collect();
-        let mut gen = Unstructured::new(&data);
-        let actions: [RandomAction; 10_000] = gen.arbitrary().unwrap();
+        let data: HeapVec<u8> = (0..1_000_000).map(|_| rng.r#gen()).collect();
+        let mut r#gen = Unstructured::new(&data);
+        let actions: [RandomAction; 10_000] = r#gen.arbitrary().unwrap();
 
         let mut rope = RichText::new(1);
         for _ in 0..10000 {


### PR DESCRIPTION
Since "gen" is a reserved keyword in Rust, I replaced it with a raw one r#gen to get rid of the error